### PR TITLE
Remove non-determinism in BeanCacheKey.java to fix flaky test BeanCacheKeyUnitTest.testEquals2Annotations

### DIFF
--- a/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java
+++ b/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java
@@ -295,7 +295,9 @@ public final class BeanCacheKey
             Method[] member1 = type1.getDeclaredMethods();
             Method[] member2 = type2.getDeclaredMethods();
 
-            // TBD: the order of the list of members seems to be deterministic
+            // Sort the arrays because the order of the list of members is not deterministic.
+            Arrays.sort(member1, Comparator.comparing(Method::toString));
+            Arrays.sort(member2, Comparator.comparing(Method::toString));
 
             int i = 0;
             int j = 0;


### PR DESCRIPTION
### Description

The test

`org.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest.testEquals2Annotations`

fails under environment [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detects flakiness under non-deterministic usages.

The potential problem is that the order of Methods returned by `GetDeclaredMethods` ([reference](https://github.com/apache/openwebbeans/blob/main/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java#L298)) is not deterministic.

Quote from [Oracle Java 8 Doc](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredMethods--):

> The elements in the returned array are not sorted and are not in any particular order.

### Reproduce

```
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -pl  webbeans-impl \
    -Dtest=org.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest#testEquals2Annotations
```

Please see the following Continuous Integration log that shows the flakiness:
https://github.com/asha-boyapati/openwebbeans/actions/runs/5041879894

This PR fixes the flaky test by removing the non-determinism in BeanCacheKey.java.

Please see the following Continuous Integration log that shows that the flakiness is fixed by this change:
https://github.com/asha-boyapati/openwebbeans/actions/runs/5041912235